### PR TITLE
build: make scripts work on a fresh clone

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,6 +42,11 @@ gulp.task("clean", function (done) {
     rimraf(webpackConfig.tests.output.path, done);
 });
 
+gulp.task("static", function (done) {
+    gulp.src("test/index.html").pipe(gulp.dest('dist'));
+    return gulp.src("node_modules/jasmine-core/lib/jasmine-core/*").pipe(gulp.dest('dist/jasmine'));
+});
+
 gulp.task("default", ["build"]);
 
 // dbmon build task

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "type": "git"
   },
   "author": "Bertrand Laporte",
+  "scripts": {
+    "build": "gulp clean && gulp static && gulp build",
+    "watch": "gulp clean && gulp static && gulp watch"
+  },
   "license": "UNLICENSED",
   "private":true,
   "bugs": {},
@@ -18,6 +22,7 @@
     "babel-preset-es2016": "^6.16.0",
     "babel-preset-es2017": "^6.16.0",
     "gulp": "^3.9.1",
+    "jasmine-core": "2.6.0",
     "rimraf": "^2.5.4",
     "webpack": "^1.13.2"
   }


### PR DESCRIPTION
Gulp tasks could be chained, but I didn't want to break existing usage.
