### PR TITLE
fix: use document.createDocumentFragment() for Edge

### DIFF
--- a/src/htmlrenderer.ts
+++ b/src/htmlrenderer.ts
@@ -48,7 +48,7 @@ class Renderer implements HtmlRenderer {
 
         this.doc = doc || {
             createDocFragment: function () {
-                return new DocumentFragment();
+                return document.createDocumentFragment();
             },
             createTextNode: function (data: string): any {
                 return document.createTextNode(data);


### PR DESCRIPTION
Calling `new DocumentFragment()` fails in Edge, see https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/9628204/