### PR TITLE
feat(template): support global vars as param initializer e.g. templat…

### DIFF
--- a/src/doc/examples/expressions/expressions.ts
+++ b/src/doc/examples/expressions/expressions.ts
@@ -6,7 +6,7 @@ function processText(t: string) {
 }
 
 // @@extract: template
-const samples = template(`(data, text = "[no text]") => {
+const samples = template(`(data, text = "[no text]", p:number = pi) => {
     <div title={data.title}> # This text has a dynamic tooltip # </div>
     <div [className]={data.className}> # This text should be blue # </div>
     <div class={data.cls}> # This text should be green # </div>
@@ -15,10 +15,12 @@ const samples = template(`(data, text = "[no text]") => {
         # This is also dynamic: {processText(text)} # 
     </div>
     <div> # This will be set only once: {::processText(text)} # </div>
+    <div> # Pi approximation: {p} # </div>
     <div class="info blue"> # >>> Click to refresh # </div>
 }`);
 
 // @@extract: instantiation
+const pi = 3.14159265358;
 let data = {
     title: "Hello World",
     className: "blue",

--- a/src/xjs/parser.ts
+++ b/src/xjs/parser.ts
@@ -320,7 +320,6 @@ export async function parse(tpl: string, filePath = "", lineOffset = 0, columnOf
             } else if (lookup(V_RW)) {
                 advance(V_RW);
                 nd.defaultValue = currentText();
-                console.log("TODO: support default value as variable: ", nd.defaultValue);
             } else {
                 // console.log(cNode)
                 error("Invalid parameter initialization");


### PR DESCRIPTION
…e((state = globalState) => {...})

*Global variable is handled like complex default values i.e. a function or a constructor
*Added an example, accessible at http://localhost:5000/examples/variableArgument/