### PR TITLE
Replacing travis-ci by GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set Node.js version
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-
+      - run: yarn --frozen-lockfile
+      - run: yarn build-all

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
- - "12"
-script:
- - yarn build-all
-cache: yarn


### PR DESCRIPTION
The [GitHub Actions feature](https://github.com/features/actions) is automatically enabled when there is a yaml file in a `workflows` folder in the `.github` folder. Unlike travis-ci, there is no need to enable anything and it is directly integrated in GitHub (in the `Actions` tab).