### PR TITLE
feat(label): support label union selectors e.g. mytemplate.query("#ba…

### DIFF
--- a/src/iv/index.ts
+++ b/src/iv/index.ts
@@ -177,18 +177,22 @@ export class Template implements IvTemplate {
      * @param label 
      * @return the DOM element or the Component api or null if nothing is found
      */
-    query(label: string, all: boolean = false): any | any[] | null {
+    query(selector: string, all: boolean = false): any | any[] | null {
         if (this.rendering) return null; // query cannot be used during template rendering
-        if (label && label.charAt(0) !== '#') {
-            error(this.view, "[$template.query()] Invalid label argument: '" + label + "' (labels must start with #)");
-            return null;
+        const labels = selector.split(';');
+        let result : any[] = [];
+        for (const label of labels) {
+            if (label && label.charAt(0) !== '#') {
+                error(this.view, "[$template.query()] Invalid label argument: '" + label + "' (labels must start with #)");
+                return null;
+            }
+            let target = this.labels ? this.labels[label] || null : null;
+            if (target && target.length) {
+                if (!all) return target[0];
+                result = result.concat(target);
+            }
         }
-        let target = this.labels ? this.labels[label] || null : null;
-        if (target && target.length) {
-            if (!all) return target[0];
-            return target
-        }
-        return null;
+        return result.length ? result : null;
     }
 
     notifyChange() {

--- a/src/test/runtime/labels.spec.ts
+++ b/src/test/runtime/labels.spec.ts
@@ -530,6 +530,19 @@ describe('Labels', () => {
         assert.equal(col![1].text, "BBB", "BBB (2)");
     });
 
+    it("should be supported by union query", async function () {
+        const tpl = template(`(condition=true) => {
+            <div #main>
+                <div #elt1/>
+                <div #elt2/>
+            </div>
+        }`);
+
+        let t = getTemplate(tpl, body).render();
+        let col = t.query("#elt1;#elt2", true)!;
+        assert.equal(col.length, 2, "both #elt1 and #elt2");
+    });
+
     // interface IvQuery<T extends Array<string>> {
     //     (selector: string, firstOnly: boolean): any | null;
     // }


### PR DESCRIPTION
…r;#baz");